### PR TITLE
moment.js should be loaded from canonical path instead of bower_components

### DIFF
--- a/calendar-select.html
+++ b/calendar-select.html
@@ -1,6 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 
-<script src="bower_components/moment/min/moment.min.js"></script>
+<script src="../moment/min/moment.min.js"></script>
 
 <!--
 A sweet calendar selector widget!


### PR DESCRIPTION
**Problem**
Currently if I install `aaronpanch/calendar-select` via bower and include `<calendar-select>` in my project, I'll get HTTP 404 eror originitating from [calendar-select.html@3](https://github.com/aaronpanch/calendar-select/blob/master/calendar-select.html#L3), which is trying to load `bower_components/moment/min/moment.min.js` from path relative to `bower_components/calendar-select`.

```
bower_components\
  calendar-select\
  moment\
```

**Proposed solution**
Dependencies, such as `moment.js` specified in `bower.json` should be loaded canonical path, that is `..\moment\` instead of `bower_components\moment\`.
